### PR TITLE
set Profiler.CallTree to nil when stopping

### DIFF
--- a/profiler.lua
+++ b/profiler.lua
@@ -183,6 +183,7 @@ function Profiler.Stop(averageMs, message)
 		text = { "", "Reason: " .. message .. "\n" }
 	end
 	log(text)
+	Profiler.CallTree = nil
 	Profiler.IsRunning = false
 end
 


### PR DESCRIPTION
This allows saving the game or `/c game.reload_mods()` after the profiler ran to work again.

I think the real reason is https://github.com/Boodals/Factorio-Profiler/blob/master/profiler.lua#L57
That profiler never gets used/logged. Not sure if you wanted to do something with it (I just log it after the dump as Total profiling time)